### PR TITLE
Fix bug in getting a TOKEN, debug by default

### DIFF
--- a/man/get_postgres_api_token.Rd
+++ b/man/get_postgres_api_token.Rd
@@ -4,7 +4,7 @@
 \alias{get_postgres_api_token}
 \title{Get a Valid Token to Access the Postgres API}
 \usage{
-get_postgres_api_token(dbg = FALSE)
+get_postgres_api_token(dbg = TRUE)
 }
 \arguments{
 \item{dbg}{if \code{TRUE}, debug messages are shown}


### PR DESCRIPTION
If the token file existed but the token was invalid, an error was raised. Now, the token is checked for validity in any case (when it existed in the fie or was retrieved from `request_token()`). Issue: #70

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kwb-r/fhpredict/71)
<!-- Reviewable:end -->
