### PR TITLE
Fix prediction

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,9 +51,7 @@ Imports:
     sf (>= 0.7.4),
     sp (>= 1.3.1),
     stringr (>= 1.4.0),
-    svglite (>= 1.2.2),
-    tidyr (>= 1.0.0),
-    xml2 (>= 1.2.2)
+    tidyr (>= 1.0.0)
 Suggests: 
     covr (>= 3.2.1),
     testthat (>= 2.2.1),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -66,5 +66,5 @@ Remotes:
     github::cloudyr/aws.s3@v0.3.12
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.0
+RoxygenNote: 7.1.1
 VignetteBuilder: knitr

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # fhpredict latest developments
 
 * rename determine_days_to_predict() to determine_date_range()
+* fix bug in predict_quality(): Distinguish between the range of days to be
+  predicted and the range of days of which to load data (one day less)
 
 # fhpredict 0.15.0 (2020-05-28)
 
@@ -13,7 +15,7 @@
 # fhpredict 0.14.0 (2020-05-28)
 
 * Fix bug in api_replace_predictions(): do not fail on missing data in db
-* Fix bug in get_indipendent_variables(): use all.vars()
+* Fix bug in get_independent_variables(): use all.vars()
 * predict_quality(): Add argument "return_debug_info"
 * provide_input_data():
     + Add argument "require_hygiene"

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # fhpredict latest developments
 
+* rename determine_days_to_predict() to determine_date_range()
+
 # fhpredict 0.15.0 (2020-05-28)
 
 * predict_quality():

--- a/R/predict_quality.R
+++ b/R/predict_quality.R
@@ -11,9 +11,9 @@
 #' @param user_id user ID
 #' @param spot_id bathing spot ID
 #' @param from Date object or date string in format yyyy-mm-dd giving the first
-#'   day of the time period to be predicted. Default: "yesterday"
+#'   day of the time period to be predicted. Default: "today"
 #' @param to Date object or date string in format yyyy-mm-dd giving the last day
-#'   of the time period to be predicted. Default: "tomorrrow"
+#'   of the time period to be predicted. Default: "today"
 #' @param import logical telling whether to import new rain data or not.
 #'   Default: \code{TRUE}.
 #' @param return_debug_info logical with default \code{FALSE}. If \code{TRUE}
@@ -39,12 +39,15 @@ predict_quality <- function(
 {
   #kwb.utils::assignPackageObjects("fhpredict")
   #kwb.utils:::assignArgumentDefaults(predict_quality)
-  #user_id=11;spot_id=57;import=FALSE
-  #user_id=9;spot_id=53;to=from
+  #user_id=11;spot_id=58;to=from;import=FALSE
 
-  # Default RADOLAN time string: latest available for the first day to predict
+  before_from <- as.Date(from) - 1L
+  before_to <- as.Date(to) - 1L
+
+  # Default RADOLAN time string: latest available for the day before the first
+  # day to predict
   radolan_time <- kwb.utils::defaultIfNULL(
-    radolan_time, utils::tail(available_radolan_times_of_day(from), 1L)
+    radolan_time, utils::tail(available_radolan_times_of_day(before_from), 1L)
   )
 
   # Try to get the model that was added last (if any)
@@ -57,13 +60,14 @@ predict_quality <- function(
   # Provide new data for prediction
   newdata <- try({
 
-    # Determine the days to be predicted
-    (days_to_predict <- determine_days_to_predict(from, to))
+    # Determine the days of which to load data and the days to be predicted
+    (data_days <- determine_date_range(before_from, before_to))
+    (prediction_days <- determine_date_range(from, to))
 
     # Load new data for the dates to predict
     if (import) {
       import_new_data(
-        user_id, spot_id, days_to_predict, radolan_time = radolan_time
+        user_id, spot_id, data_days, radolan_time = radolan_time
       )
     }
 
@@ -71,10 +75,18 @@ predict_quality <- function(
     spot_data <- provide_input_data(user_id, spot_id, require_hygiene = FALSE)
 
     # Prepare the data (filter for bathing season, log-transform rain)
-    riverdata_raw <- prepare_river_data(spot_data)
+    riverdata <- prepare_river_data(spot_data)
+
+    # Add fake entry (with all values 0) for the "to" date
+    riverdata <- lapply(riverdata, function(df) {
+      template <- df[1L, ]
+      template[, 1L] <- as.POSIXct(paste0(to, "00:00:00"))
+      template[, -1L] <- 0
+      rbind(df, template)
+    })
 
     # Calculate daily means just in case there is more than one record per day
-    riverdata <- lapply(riverdata_raw, calculate_daily_means)
+    riverdata <- lapply(riverdata, calculate_daily_means)
 
     #identify_date_duplicates(riverdata_raw)
     stopifnot(all(lengths(identify_date_duplicates(riverdata)) == 0L))
@@ -84,14 +96,14 @@ predict_quality <- function(
 
     stopifnot(length(identify_date_duplicates(newdata_raw)) == 0L)
 
-    # Filter for the days to predict!
+    # Filter for the dates to be predicted
     all_dates <- substr(newdata_raw$datum, 1, 10)
 
-    use_me <- all_dates %in% as.character(days_to_predict)
+    use_me <- all_dates %in% as.character(prediction_days)
 
     if (! any(use_me)) clean_stop(
-      "No data available for these days to be predicted: ",
-      kwb.utils::stringList(as.character(days_to_predict))
+      "No data available for these required days for prediction: ",
+      kwb.utils::stringList(as.character(data_days))
     )
 
     #kwb.utils::removeColumns(newdata[use_me, ], "log_e.coli")
@@ -101,7 +113,9 @@ predict_quality <- function(
 
     # Keep only the rows related to days to be predicted and keep only the
     # variables that are required by the model
-    kwb.utils::selectColumns(newdata_raw[use_me, ], c("datum", model_vars))
+    columns <- c("datum", model_vars)
+
+    newdata <- kwb.utils::selectColumns(newdata_raw[use_me, ], columns)
   })
 
   if (is_error(newdata)) {
@@ -114,15 +128,6 @@ predict_quality <- function(
     prediction <- rstanarm::posterior_predict(model, newdata = newdata)
 
     percentiles <- finish_prediction(prediction, newdata)
-
-    # Delete all predictions
-    # api_delete_predictions(user_id, spot_id)
-    #
-    # # Add predictions to the database
-    # add_timeseries_to_database(
-    #   path = path_predictions(user_id, spot_id),
-    #   data = percentiles
-    # )
 
     if (return_debug_info) {
 

--- a/R/predict_quality.R
+++ b/R/predict_quality.R
@@ -41,14 +41,14 @@ predict_quality <- function(
   #kwb.utils:::assignArgumentDefaults(predict_quality)
   #user_id=11;spot_id=58;to=from;import=FALSE
 
-  before_from <- as.Date(from) - 1L
-  before_to <- as.Date(to) - 1L
+  (before_from <- as.Date(from) - 1L)
+  (before_to <- as.Date(to) - 1L)
 
   # Default RADOLAN time string: latest available for the day before the first
   # day to predict
-  radolan_time <- kwb.utils::defaultIfNULL(
+  (radolan_time <- kwb.utils::defaultIfNULL(
     radolan_time, utils::tail(available_radolan_times_of_day(before_from), 1L)
-  )
+  ))
 
   # Try to get the model that was added last (if any)
   model <- try(get_last_added_model(user_id, spot_id))

--- a/R/predict_quality.R
+++ b/R/predict_quality.R
@@ -156,8 +156,8 @@ predict_quality <- function(
   ))
 }
 
-# determine_days_to_predict ----------------------------------------------------
-determine_days_to_predict <- function(from = NULL, to = NULL)
+# determine_date_range ---------------------------------------------------------
+determine_date_range <- function(from = NULL, to = NULL)
 {
   #kwb.utils::assignPackageObjects("fhpredict");from=NULL;to=NULL
   from_missing <- is.null(from)
@@ -174,7 +174,7 @@ determine_days_to_predict <- function(from = NULL, to = NULL)
   }
 
   clean_stop(
-    "Either 'from' or 'to' must be given to 'determine_days_to_predict'"
+    "Either 'from' or 'to' must be given to 'determine_date_range'"
   )
 }
 

--- a/R/predict_quality.R
+++ b/R/predict_quality.R
@@ -64,7 +64,7 @@ predict_quality <- function(
     (data_days <- determine_date_range(before_from, before_to))
     (prediction_days <- determine_date_range(from, to))
 
-    # Load new data for the dates to predict
+    # Load new (rain) data required for the prediction
     if (import) {
       import_new_data(
         user_id, spot_id, data_days, radolan_time = radolan_time
@@ -84,7 +84,7 @@ predict_quality <- function(
     # Calculate daily means just in case there is more than one record per day
     riverdata <- lapply(riverdata, calculate_daily_means)
 
-    #identify_date_duplicates(riverdata)
+    #identify_date_duplicates(riverdata_raw)
     stopifnot(all(lengths(identify_date_duplicates(riverdata)) == 0L))
 
     # Provide data frame with all additional variables, as required by the model

--- a/R/predict_quality.R
+++ b/R/predict_quality.R
@@ -105,13 +105,11 @@ predict_quality <- function(
     #kwb.utils::removeColumns(newdata[use_me, ], "log_e.coli")
 
     # Names of variables that are acutally used by the model
-    model_vars <- get_indipendent_variables(model$formula)
+    model_vars <- get_independent_variables(model$formula)
 
     # Keep only the rows related to days to be predicted and keep only the
     # variables that are required by the model
-    columns <- c("datum", model_vars)
-
-    newdata <- kwb.utils::selectColumns(newdata_raw[use_me, ], columns)
+    kwb.utils::selectColumns(newdata_raw[use_me, ], c("datum", model_vars))
   })
 
   if (is_error(newdata)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -202,8 +202,8 @@ get_environment_var <- function(name)
   clean_stop(sprintf("Please set the environment variable '%s'", name))
 }
 
-# get_indipendent_variables ----------------------------------------------------
-get_indipendent_variables <- function(x)
+# get_independent_variables ----------------------------------------------------
+get_independent_variables <- function(x)
 {
   stopifnot(rlang::is_formula(x))
 

--- a/man/predict_quality.Rd
+++ b/man/predict_quality.Rd
@@ -20,10 +20,10 @@ predict_quality(
 \item{spot_id}{bathing spot ID}
 
 \item{from}{Date object or date string in format yyyy-mm-dd giving the first
-day of the time period to be predicted. Default: "yesterday"}
+day of the time period to be predicted. Default: "today"}
 
 \item{to}{Date object or date string in format yyyy-mm-dd giving the last day
-of the time period to be predicted. Default: "tomorrrow"}
+of the time period to be predicted. Default: "today"}
 
 \item{import}{logical telling whether to import new rain data or not.
 Default: \code{TRUE}.}

--- a/tests/testthat/test-function-determine_days_to_predict.R
+++ b/tests/testthat/test-function-determine_days_to_predict.R
@@ -1,6 +1,6 @@
-test_that("determine_days_to_predict() works", {
+test_that("determine_date_range() works", {
 
-  f <- fhpredict:::determine_days_to_predict
+  f <- fhpredict:::determine_date_range
 
   date <- "2019-07-05"
 


### PR DESCRIPTION
Hi @wseis, 

I changed the `predict_quality()` function as we discussed it. The data is loaded for the day(s) one day before the day(s) to be predicted. A "fake" record (full of zeros) is added for the (last) day to be predicted if it does not yet exist. This fixes the error that was reported by @fabianmoronzirfas. It occurred because rain data was available for today but river flow and wwtp flow were available only for yesterday. The merge led to `NA` values within the `newdata` data frame.

Feel free to add your "last" change (that you wanted to integrate before we make a new release) to this branch. Then, merge this pull request. Contact me if you need assistance.

Regards,
Hauke

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kwb-r/fhpredict/74)
<!-- Reviewable:end -->
